### PR TITLE
[#409] Keep showing keyboard over Home screen

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -35,9 +35,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -101,7 +103,7 @@ fun PreviewRestoreComplete() {
 }
 
 // TODO [#409]: https://github.com/zcash/secant-android-wallet/issues/409
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun RestoreWallet(
     completeWordList: Set<String>,
@@ -118,6 +120,10 @@ fun RestoreWallet(
                 RestoreMainContent(completeWordList, userWordList, paste)
             }
         } else {
+            // In some cases we need to hide the software keyboard manually, as it stays shown after
+            // all words are filled successfully.
+            LocalSoftwareKeyboardController.current?.hide()
+
             RestoreComplete(onComplete = onFinished)
         }
     }


### PR DESCRIPTION
In some cases we need to hide the software keyboard manually, as it stays shown after all words are filled successfully.

- Implemented with `LocalSoftwareKeyboardController`.
- The alternative way of implementation with `LocalFocusManager` didn't work so well here.

Closes https://github.com/zcash/secant-android-wallet/issues/409.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Manual tests: Did you update the [manual tests](../blob/main/docs/testing/manual_testing) as appropriate? _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed._ Code Coverage can be run with: `./gradlew connectedCheck -PIS_COVERAGE_ENABLED=true`
- [ ] Documentation: Did you update documentation as appropriate? (e.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes?
- [ ] Screenshots: Did you provide before and after UI screenshots in the description of this pull request?  _This is only applicable for changes that modify the UI._
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._


# Reviewer

- [x] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) checklist?
- [x] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after changes and when possible, leave it in a better place._
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._