### PR TITLE
Reproduce crash in lint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -161,7 +161,7 @@ jobs:
           # Disable minify, since it makes lint run faster
           ORG_GRADLE_PROJECT_IS_MINIFY_ENABLED: false
         run: |
-          ./gradlew :app:lintZcashmainnetRelease
+          ./gradlew lint
       - name: Collect Artifacts
         if: ${{ always() }}
         timeout-minutes: 1


### PR DESCRIPTION
Do not merge.  This is for reporting a reproducible bug to Google in Android lint.  I want the CI job to run which shows the failure occurring.